### PR TITLE
Add templates for promoting features

### DIFF
--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -32,7 +32,7 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 - [ ] Test coverage is >= 70%
 - [ ] Integration tests cover core use cases with the feature enabled. 
 - [ ] When disabled, the feature does not affect system stability or performance. 
-- [ ] Feature coverage and test plans written for user facing changes
+- [ ] Feature coverage and test plans written and approved
 
 
 **Performance**
@@ -46,4 +46,3 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 
 - [ ] Reviewed by the appropriate workgroup and added to the workgroup roadmap.
 - [ ] Approved by TOC.
-

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -1,0 +1,49 @@
+---
+name: Alpha Feature Requirements
+about: Requirements for promoting a feature to alpha
+---
+
+This page lists the requirements for promoting a feature to alpha. Please check off and document the steps as they are completed.
+
+**Feature Name:** 
+--- 
+
+### Requirements: 
+
+**Design**
+
+- [ ] Requires approved RFC in order to merge. 
+
+**Config**
+
+- [ ] Requires explicit user action to enable (e.g. a config field, config resource, or installation action). 
+
+**Docs**
+
+- [ ] Reference docs are published to istio.io. 
+- [ ] Basic feature docs are published on istio.io describing what the feature does, how to use it, and any caveats. 
+- [ ] Whenever possible, documentation has automated istio.io tests written. 
+- [ ] A reference to the design doc/issue is published on istio.io. 
+- [ ] Release notes entries added as appropriate
+- [ ] Upgrade notes entries added as appropriate
+
+**Tests**
+
+- [ ] Test coverage is >= 70%
+- [ ] Integration tests cover core use cases with the feature enabled. 
+- [ ] When disabled, the feature does not affect system stability or performance. 
+- [ ] Feature coverage and test plans written for user facing changes
+
+
+**Performance**
+- [ ] Performance requirements assessed as part of the design. 
+
+**API**
+
+- [ ] (Optional) Initial API review.
+
+**Promotion**
+
+- [ ] Reviewed by the appropriate workgroup and added to the workgroup roadmap.
+- [ ] Approved by TOC.
+

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -5,8 +5,14 @@ about: Requirements for promoting a feature to alpha
 
 This page lists the requirements for promoting a feature to alpha. Please check off and document the steps as they are completed.
 
-**Feature Name:** 
+**Feature Name:**  
+
 **Design doc:**
+
+**Relevant documentation:**
+
+```
+```
 --- 
 
 ### Requirements: 
@@ -26,15 +32,7 @@ Link to instructions for enabling
 **Docs**
 
 - [ ] Reference docs are published to Istio.io, or the Istio wiki.
-
-```
-Links to docs
-```
-
 - [ ] Basic feature docs are published on istio.io describing what the feature does, how to use it, and any caveats. 
-```
-Links to docs
-```
 - [ ] Release notes entries added as appropriate
 - [ ] Upgrade notes entries added as appropriate
 
@@ -46,7 +44,7 @@ Links to docs
 
 
 **Performance**
-- [ ] Performance requirements assessed as part of the design. 
+- [ ] Performance impacts have been measured. 
 
 **API**
 
@@ -54,5 +52,8 @@ Links to docs
 
 **Promotion**
 
-- [ ] Reviewed by the appropriate workgroup and added to the workgroup roadmap.
-- [ ] Approved by TOC.
+
+- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [ ] The supportability review panel has reviewed promotion of the feature.  
+- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+	roadmap for a release.

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -6,31 +6,41 @@ about: Requirements for promoting a feature to alpha
 This page lists the requirements for promoting a feature to alpha. Please check off and document the steps as they are completed.
 
 **Feature Name:** 
+**Design doc:**
 --- 
 
 ### Requirements: 
 
 **Design**
 
-- [ ] Requires approved RFC in order to merge. 
+- [ ] RFC has been approved. 
 
 **Config**
 
-- [ ] Requires explicit user action to enable (e.g. a config field, config resource, or installation action). 
+- [ ] Explicit user action is required to enable this feature (e.g. a config field, config resource, or installation action). 
+
+```
+Link to instructions for enabling
+```
 
 **Docs**
 
-- [ ] Reference docs are published to istio.io. 
+- [ ] Reference docs are published to Istio.io, or the Istio wiki.
+
+```
+Links to docs
+```
+
 - [ ] Basic feature docs are published on istio.io describing what the feature does, how to use it, and any caveats. 
-- [ ] Whenever possible, documentation has automated istio.io tests written. 
-- [ ] A reference to the design doc/issue is published on istio.io. 
+```
+Links to docs
+```
 - [ ] Release notes entries added as appropriate
 - [ ] Upgrade notes entries added as appropriate
 
 **Tests**
 
-- [ ] Test coverage is >= 70%
-- [ ] Integration tests cover core use cases with the feature enabled. 
+- [ ] Automated integration tests cover core use cases with the feature enabled. 
 - [ ] When disabled, the feature does not affect system stability or performance. 
 - [ ] Feature coverage and test plans written and approved
 
@@ -40,7 +50,7 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 
 **API**
 
-- [ ] (Optional) Initial API review.
+- [ ] Initial API review.
 
 **Promotion**
 

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -9,6 +9,8 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 
 **Feature Name:**  
 
+**RFC:**
+
 **Design doc:**
 
 **Relevant Documentation:**
@@ -25,14 +27,12 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 
 - [ ] Explicit user action is required to enable this feature (e.g. a config field, config resource, or installation action). 
 
-```
-Link to instructions for enabling
-```
+> Link to instructions for enabling
 
 **Docs**
 
-- [ ] Reference docs are published to Istio.io, or the Istio wiki.
-- [ ] Basic feature docs are published on istio.io describing what the feature does, how to use it, and any caveats. 
+- [ ] Reference docs are published to preliminary.istio.io or the Istio wiki.
+- [ ] Basic feature docs are published on preliminary.istio.io describing what the feature does, how to use it, and any caveats. 
 - [ ] Release notes entries added as appropriate
 - [ ] Upgrade notes entries added as appropriate
 
@@ -45,6 +45,8 @@ Link to instructions for enabling
 
 **Performance**
 - [ ] Performance impacts have been measured. Please document any initial performance tests below:
+
+> Initial performance tests
 
 **API**
 

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -21,7 +21,7 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 
 **Design**
 
-- [ ] RFC has been approved. 
+- [ ] RFC has been approved describing the intention of the feature as well as the user stories behind the feature. 
 
 **Config**
 
@@ -40,13 +40,6 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 
 - [ ] Automated integration tests cover core use cases with the feature enabled. 
 - [ ] When disabled, the feature does not affect system stability or performance. 
-- [ ] Feature coverage and test plans written and approved
-
-
-**Performance**
-- [ ] Performance impacts have been measured. Please document any initial performance tests below:
-
-> Initial performance tests
 
 **API**
 
@@ -55,6 +48,5 @@ This page lists the requirements for promoting a feature to alpha. Please check 
 **Approvals**
 
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The supportability review panel has reviewed promotion of the feature.  
 - [ ] The TOC has reviewed and approved promotion of the feature as part of the
 	roadmap for a release.

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -3,16 +3,16 @@ name: Alpha Feature Requirements
 about: Requirements for promoting a feature to alpha
 ---
 
+# Alpha Feature Requirements
+
 This page lists the requirements for promoting a feature to alpha. Please check off and document the steps as they are completed.
 
 **Feature Name:**  
 
 **Design doc:**
 
-**Relevant documentation:**
+**Relevant Documentation:**
 
-```
-```
 --- 
 
 ### Requirements: 
@@ -44,16 +44,13 @@ Link to instructions for enabling
 
 
 **Performance**
-- [ ] Performance impacts have been measured. Please document below: 
-```
-```
+- [ ] Performance impacts have been measured. Please document any initial performance tests below:
 
 **API**
 
 - [ ] Initial API review.
 
-**Promotion**
-
+**Approvals**
 
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
 - [ ] The supportability review panel has reviewed promotion of the feature.  

--- a/.github/ISSUE_TEMPLATE/alpha_feature.md
+++ b/.github/ISSUE_TEMPLATE/alpha_feature.md
@@ -44,7 +44,9 @@ Link to instructions for enabling
 
 
 **Performance**
-- [ ] Performance impacts have been measured. 
+- [ ] Performance impacts have been measured. Please document below: 
+```
+```
 
 **API**
 

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -54,5 +54,5 @@ This page lists the requirements for promoting a feature to beta. Please check o
 **Promotion**
 
 - [ ] The decision to promote a feature is presented and approved by the workgroup. 
-- [ ] The decision to promote a feature is approved by the TOC in the roadmap for a release. 
+- [ ] The decision to promote the feature has been approved by the TOC.
 - [ ] Supportability review addressing support scenario questions that has been discussed in the appropriate workgroup.

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -12,7 +12,7 @@ This page lists the requirements for promoting a feature to beta. Please check o
 
 **Design**
 
-- [ ] Design doc has been approved
+- [ ] Design doc has been approved by relevant WG leads
 
 **Config**
 
@@ -56,4 +56,3 @@ This page lists the requirements for promoting a feature to beta. Please check o
 - [ ] The decision to promote a feature is presented and approved by the workgroup. 
 - [ ] The decision to promote a feature is approved by the TOC in the roadmap for a release. 
 - [ ] Supportability review addressing support scenario questions that has been discussed in the appropriate workgroup.
-

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -3,9 +3,17 @@ name: Beta Feature Requirements
 about: Requirements for promoting a feature to beta
 ---
 
-This page lists the requirements for promoting a feature to beta. Please check off and document the steps as they are completed.
+This page lists the requirements for promoting a feature to beta. Promotion to beta must meet all requirements for promotion to alpha. Please check off and document the steps as they are completed.
 
 **Feature Name:** 
+
+**Promotion to Alpha:**
+
+**Relevant documentation:**
+
+```
+```
+
 --- 
 
 ### Requirements: 
@@ -44,10 +52,11 @@ This page lists the requirements for promoting a feature to beta. Please check o
 
 **Bugs**
 
-- [ ] Feature has no outstanding P0 bugs
+- [ ] Feature has no known major issues.
 
 **Promotion**
 
-- [ ] The decision to promote the feature has been presented and approved by the appropriate work groups. 
-- [ ] The decision to promote the feature has been presented to (and approved by) the supportability review panel. 
-- [ ] The decision to promote the feature has been approved by the TOC.
+- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [ ] The supportability review panel has reviewed promotion of the feature.  
+- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+	road map for a release.

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -33,7 +33,7 @@ This page lists the requirements for promoting a feature to beta. Please check o
 - [ ] Integration tests cover feature edge cases
 - [ ] End-to-end tests cover samples/tutorials
 - [ ] Fixed issues have tests to prevent regressions
-- [ ] Ensure that coverage exists for the feature in stability/stress test suite.
+- [ ] Stability/stress test suite includes coverage for the feature.
 
 **Performance**
 

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -40,15 +40,15 @@ This page lists the requirements for promoting a feature to beta. Promotion to b
 
 **Performance**
 
-- [ ] Feature has baseline performance tests
+- [ ] Performance results and impacts with feature enabled are published on istio.io.
 
 **API**
 
 - [ ] TOC has reviewed the API and determined it to be complete. 
 
-**CLI**
+**Tooling**
 
-- [ ] Any necessary CLI commands have been implemented and are complete. 
+- [ ] Any necessary tooling to use/debug the feature has been implemented and is complete. 
 
 **Bugs**
 

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -1,0 +1,59 @@
+---
+name: Beta Feature Requirements
+about: Requirements for promoting a feature to beta
+---
+
+This page lists the requirements for promoting a feature to beta. Please check off and document the steps as they are completed.
+
+**Feature Name:** 
+--- 
+
+### Requirements: 
+
+**Design**
+
+- [ ] Design doc has been approved
+
+**Config**
+
+- [ ] Can be enabled by default without requiring explicit user action. 
+
+**Docs** 
+
+- [ ] Performance expectations are documented, may have caveats. 
+- [ ] Documentation on istio.io includes samples/tutorials. 
+- [ ] Documentation on istio.io includes appropriate glossary entries. 
+- [ ] Where possible, all documentation changes have istio.io tests written. 
+- [ ] Release notes have been added. 
+- [ ] Upgrade notes have been added. 
+
+**Tests**
+
+- [ ] Test coverage is >= 80%
+- [ ] Integration tests cover feature edge cases
+- [ ] End-to-end tests cover samples/tutorials
+- [ ] Fixed issues have tests to prevent regressions
+- [ ] Ensure that coverage exists for the feature in stability/stress test suite.
+
+**Performance**
+
+- [ ] Feature has baseline performance tests
+
+**API**
+
+- [ ] API has had a thorough API review and is thought to be complete. 
+
+**CLI**
+
+- [ ] Necesssary CLI command has been implemented and are complete. 
+
+**Bugs**
+
+- [ ] Feature has no outstanding P0 bugs
+
+**Promotion**
+
+- [ ] The decision to promote a feature is presented and approved by the workgroup. 
+- [ ] The decision to promote a feature is approved by the TOC in the roadmap for a release. 
+- [ ] Supportability review addressing support scenario questions that has been discussed in the appropriate workgroup.
+

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -3,16 +3,15 @@ name: Beta Feature Requirements
 about: Requirements for promoting a feature to beta
 ---
 
+# Beta Feature Requirements
+
 This page lists the requirements for promoting a feature to beta. Promotion to beta must meet all requirements for promotion to alpha. Please check off and document the steps as they are completed.
 
 **Feature Name:** 
 
-**Promotion to Alpha:**
+**Alpha Checklist:**
 
-**Relevant documentation:**
-
-```
-```
+**Relevant Documentation:**
 
 --- 
 
@@ -54,7 +53,7 @@ This page lists the requirements for promoting a feature to beta. Promotion to b
 
 - [ ] Feature has no known major issues.
 
-**Promotion**
+**Approvals**
 
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
 - [ ] The supportability review panel has reviewed promotion of the feature.  

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -45,7 +45,7 @@ This page lists the requirements for promoting a feature to beta. Please check o
 
 **CLI**
 
-- [ ] Necesssary CLI command has been implemented and are complete. 
+- [ ] Any necessary CLI commands have been implemented and are complete. 
 
 **Bugs**
 

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -9,6 +9,8 @@ This page lists the requirements for promoting a feature to beta. Promotion to b
 
 **Feature Name:** 
 
+**Design Doc:**
+
 **Alpha Checklist:**
 
 **Relevant Documentation:**
@@ -39,7 +41,7 @@ This page lists the requirements for promoting a feature to beta. Promotion to b
 
 **Performance**
 
-- [ ] Performance results and impacts with feature enabled are published on istio.io.
+- [ ] Tests exist with the feature enabled that can be integrated with our automated performance testing.
 
 **API**
 

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -21,7 +21,10 @@ This page lists the requirements for promoting a feature to beta. Promotion to b
 
 **Design**
 
-- [ ] Design doc has been approved by relevant work group leads
+- [ ] Design doc describing the intention of the feature, how it will be
+	implemented, and any thoughts on how to test the feature has been approved by
+	relevant work group leads
+- [ ] Feature coverage and test plans written and approved.
 
 **Docs** 
 
@@ -41,6 +44,7 @@ This page lists the requirements for promoting a feature to beta. Promotion to b
 
 **Performance**
 
+- [ ] Feature coverage and test plans written and approved 
 - [ ] Tests exist with the feature enabled that can be integrated with our automated performance testing.
 
 **API**

--- a/.github/ISSUE_TEMPLATE/beta_feature.md
+++ b/.github/ISSUE_TEMPLATE/beta_feature.md
@@ -12,24 +12,19 @@ This page lists the requirements for promoting a feature to beta. Please check o
 
 **Design**
 
-- [ ] Design doc has been approved by relevant WG leads
-
-**Config**
-
-- [ ] Can be enabled by default without requiring explicit user action. 
+- [ ] Design doc has been approved by relevant work group leads
 
 **Docs** 
 
-- [ ] Performance expectations are documented, may have caveats. 
+- [ ] Documentation on istio.io includes performance expectations; may have caveats. 
 - [ ] Documentation on istio.io includes samples/tutorials. 
 - [ ] Documentation on istio.io includes appropriate glossary entries. 
-- [ ] Where possible, all documentation changes have istio.io tests written. 
+- [ ] All new documentation containing user actions includes istio.io tests.
 - [ ] Release notes have been added. 
 - [ ] Upgrade notes have been added. 
 
 **Tests**
 
-- [ ] Test coverage is >= 80%
 - [ ] Integration tests cover feature edge cases
 - [ ] End-to-end tests cover samples/tutorials
 - [ ] Fixed issues have tests to prevent regressions
@@ -41,7 +36,7 @@ This page lists the requirements for promoting a feature to beta. Please check o
 
 **API**
 
-- [ ] API has had a thorough API review and is thought to be complete. 
+- [ ] TOC has reviewed the API and determined it to be complete. 
 
 **CLI**
 
@@ -53,6 +48,6 @@ This page lists the requirements for promoting a feature to beta. Please check o
 
 **Promotion**
 
-- [ ] The decision to promote a feature is presented and approved by the workgroup. 
+- [ ] The decision to promote the feature has been presented and approved by the appropriate work groups. 
+- [ ] The decision to promote the feature has been presented to (and approved by) the supportability review panel. 
 - [ ] The decision to promote the feature has been approved by the TOC.
-- [ ] Supportability review addressing support scenario questions that has been discussed in the appropriate workgroup.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -6,7 +6,7 @@ about: Requirements for experimental features
 # Experimental Feature Requirements
 
 This page lists the requirements for experimental features. Experimental features allow Istio work groups to collect more information
-on potential new functionality. This template should be completed users try out any new experimental features. Please check off and 
+on potential new functionality. This template should be completed before users try out any new experimental features. Please check off and 
 document the steps as they are completed.
 
 **Feature Name:** 
@@ -18,6 +18,7 @@ document the steps as they are completed.
 - [ ] Feature is reviewed in a work group meeting
 - [ ] RFC has been written
 - [ ] Feature is disabled by default
+- [ ] No impact on performance when the feature is disabled.
 - [ ] Steps for enabling the feature have been documented. This may include
 	instructions for building, running an `istioctl experimental command`, or
 	using the preview profile. 
@@ -25,4 +26,3 @@ document the steps as they are completed.
 - [ ] Plan exists for getting feedback. This may include user feedback meetings,
 	discuss.istio.io conversations, GitHub issues, or mailing lists. 
 > Plan for feedback
-- [ ] No impact on performance when the feature is disabled.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -22,7 +22,10 @@ document the steps as they are completed.
 - [ ] Steps for enabling the feature have been documented. This may include
 	instructions for building, running an `istioctl experimental command`, or
 	using the preview profile. 
-	**Link to instructions:** 
+
+> Link to instructions 
+
 - [ ] Plan exists for getting feedback. This may include user feedback meetings,
 	discuss.istio.io conversations, GitHub issues, or mailing lists. 
+
 > Plan for feedback

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -3,7 +3,11 @@ name: Experimental Feature Requirements
 about: Requirements for experimental features
 ---
 
-This page lists the requirements for experimental features. Please check off and document the steps as they are completed.
+# Experimental Feature Requirements
+
+This page lists the requirements for experimental features. Experimental features allow Istio work groups to collect more information
+on potential new functionality. This template should be completed users try out any new experimental features. Please check off and 
+document the steps as they are completed.
 
 **Feature Name:** 
 
@@ -16,13 +20,9 @@ This page lists the requirements for experimental features. Please check off and
 - [ ] Feature is disabled by default
 - [ ] Steps for enabling the feature have been documented. This may include
 	instructions for building, running an `istioctl experimental command`, or
-	using the preview profile.
-```
-Link to instructions
-```
+	using the preview profile. 
+	**Link to instructions:** 
 - [ ] Plan exists for getting feedback. This may include user feedback meetings,
 	discuss.istio.io conversations, GitHub issues, or mailing lists. 
-```
-Plan for feedback
-```
+> Plan for feedback
 - [ ] No impact on performance when the feature is disabled.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -1,0 +1,17 @@
+---
+name: Experimental Feature Requirements
+about: Requirements for experimental features
+---
+
+This page lists the requirements for experimental features. Please check off and document the steps as they are completed.
+
+**Feature Name:** 
+--- 
+
+### Requirements: 
+
+- [ ] Feature is reviewed in a TOC meeting
+- [ ] Design document has been written
+- [ ] Feature is disabled by default
+- [ ] Steps for enabling the feature have been documented
+- [ ] Plan exists for getting feedback

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -6,6 +6,7 @@ about: Requirements for experimental features
 This page lists the requirements for experimental features. Please check off and document the steps as they are completed.
 
 **Feature Name:** 
+
 --- 
 
 ### Requirements: 

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -25,3 +25,4 @@ Link to instructions
 ```
 Plan for feedback
 ```
+- [ ] No impact on performance when the feature is disabled.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -10,8 +10,17 @@ This page lists the requirements for experimental features. Please check off and
 
 ### Requirements: 
 
-- [ ] Feature is reviewed in a TOC meeting
-- [ ] Design document has been written
+- [ ] Feature is reviewed in a work group meeting
+- [ ] RFC has been written
 - [ ] Feature is disabled by default
-- [ ] Steps for enabling the feature have been documented
-- [ ] Plan exists for getting feedback
+- [ ] Steps for enabling the feature have been documented. This may include
+	instructions for building, running an `istioctl experimental command`, or
+	using the preview profile.
+```
+Link to instructions
+```
+- [ ] Plan exists for getting feedback. This may include user feedback meetings,
+	discuss.istio.io conversations, GitHub issues, or mailing lists. 
+```
+Plan for feedback
+```

--- a/.github/ISSUE_TEMPLATE/stable_feature.md
+++ b/.github/ISSUE_TEMPLATE/stable_feature.md
@@ -19,10 +19,6 @@ This page lists the requirements for promoting a feature to stable. Promotion to
 
 ### Requirements: 
 
-**Tests**
-
-- [ ] Automated tests are in place to prevent regressions. 
-
 **Performance**
 
 - [ ] Latency, throughput, and scalability are quantified and documented on

--- a/.github/ISSUE_TEMPLATE/stable_feature.md
+++ b/.github/ISSUE_TEMPLATE/stable_feature.md
@@ -1,0 +1,30 @@
+---
+name: Stable Feature Requirements
+about: Requirements for promoting a feature to stable
+---
+
+This page lists the requirements for promoting a feature to stable. Please check off and document the steps as they are completed.
+
+**Feature Name:** 
+--- 
+
+### Requirements: 
+
+**Tests**
+
+- [ ] Test coverage is >= 90%
+- [ ] Automated tests are in place to prevent performance regressions. 
+
+**Performance**
+
+- [ ] Latency, throughput, and scale are quantified and documented. 
+
+**Bugs**
+
+- [ ] Feature has no outstanding P0 or P1 bugs. 
+
+**Performance**
+
+- [ ] The decision to promote a feature is presented in the roadmap of the appropriate working group. 
+- [ ] TOC has approved promotion. 
+

--- a/.github/ISSUE_TEMPLATE/stable_feature.md
+++ b/.github/ISSUE_TEMPLATE/stable_feature.md
@@ -3,28 +3,39 @@ name: Stable Feature Requirements
 about: Requirements for promoting a feature to stable
 ---
 
-This page lists the requirements for promoting a feature to stable. Please check off and document the steps as they are completed.
+This page lists the requirements for promoting a feature to stable. Promotion to stable must meet all requirements of promotion to beta. Please check off and document the steps as they are completed.
 
 **Feature Name:** 
+
+**Promotion to Alpha:**
+
+**Promotion to Beta:**
+
+**Relevant Documentation:**
+
+```
+```
+
 --- 
 
 ### Requirements: 
 
 **Tests**
 
-- [ ] Test coverage is >= 90%
-- [ ] Automated tests are in place to prevent performance regressions. 
+- [ ] Automated tests are in place to prevent regressions. 
 
 **Performance**
 
-- [ ] Latency, throughput, and scale are quantified and documented. 
+- [ ] Latency, throughput, and scalability are quantified and documented on
+	istio.io. 
 
 **Bugs**
 
-- [ ] Feature has no outstanding P0 or P1 bugs. 
+- [ ] Feature has no known major issues. 
 
 **Performance**
 
-- [ ] The decision to promote a feature is presented in the roadmap of the appropriate working group. 
-- [ ] TOC has approved promotion. 
-
+- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [ ] The supportability review panel has reviewed promotion of the feature.  
+- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+	roadmap for a release.

--- a/.github/ISSUE_TEMPLATE/stable_feature.md
+++ b/.github/ISSUE_TEMPLATE/stable_feature.md
@@ -3,18 +3,17 @@ name: Stable Feature Requirements
 about: Requirements for promoting a feature to stable
 ---
 
+# Stable Feature Requirements
+
 This page lists the requirements for promoting a feature to stable. Promotion to stable must meet all requirements of promotion to beta. Please check off and document the steps as they are completed.
 
 **Feature Name:** 
 
-**Promotion to Alpha:**
+**Alpha Checklist:**
 
-**Promotion to Beta:**
+**Beta Checklist:**
 
 **Relevant Documentation:**
-
-```
-```
 
 --- 
 
@@ -33,7 +32,7 @@ This page lists the requirements for promoting a feature to stable. Promotion to
 
 - [ ] Feature has no known major issues. 
 
-**Performance**
+**Approvals**
 
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
 - [ ] The supportability review panel has reviewed promotion of the feature.  


### PR DESCRIPTION
This PR adds templates for promoting issues to experimental/alpha/beta/stable maturity levels. It's modeled after the [definition of done](https://docs.google.com/document/d/1--lBkoFx6LMwlLayAJo4BH3rc8naPtcRiXDYAvoGULA/edit?usp=sharing) and [feature lifecycle checklist](https://github.com/istio/community/blob/master/FEATURE-LIFECYCLE-CHECKLIST.md). Before any feature gets promoted, it is expected to complete the checklist.   