### PR TITLE
This improves the experimental feature template

### DIFF
--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -13,9 +13,7 @@ about: Requirements for an experimental feature
 
 [//]: # (The feature implementation section must be completed before submission of the issue.)
 
-
-
-# Feature Information
+# Feature:
 
 [//]: # (All information in this section is mandatory for new issue submission.)
 
@@ -27,12 +25,9 @@ about: Requirements for an experimental feature
 
 [//]: # (The primary lead or leads responsible for the feature. These individuals serve as a point of contact for the feature.)
 
-
 **Short description:**
 
 [//]: # (A short description of the feature. One or two sentences maximum.)
-
---- 
 
 # Requirements:
 
@@ -62,7 +57,7 @@ about: Requirements for an experimental feature
 
 - [ ] [Feedback plan](insert_your_link_here).
 
-[//]: # (This may include user feedback meetings, discuss.istio.io conversations, GitHub issues, or mailing lists.a)
+[//]: # (This may include user feedback meetings, discuss.istio.io conversations, GitHub issues, or mailing lists.)
 
 - [ ] Disabled by default.
 - [ ] No impact on performance when the feature is disabled.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -60,4 +60,5 @@ about: Requirements for an experimental feature
 [//]: # (This may include user feedback meetings, discuss.istio.io conversations, GitHub issues, or mailing lists.)
 
 - [ ] Disabled by default.
+
 - [ ] No impact on performance when the feature is disabled.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -35,7 +35,7 @@ This template shall be completed before users are exposed to any new experimetna
 
 **User stories document:**
 
-**RFC document:**
+**RFC document:** [create an RFC using template](https://docs.google.com/document/d/1ewJoCcw5-04crH-M0xw4zFxz1cfwVCPnNyW4K3m4Yyc/template/preview)
 
 **Instructions document:**
 

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -49,7 +49,7 @@ about: Requirements for an experimental feature
 [//]: # (An RFC is mandatory to graduate to experimental. The RFC does not have to be reviewed in a work group)
 [//]: # (meeting to graduate to experimental.)
 
-- [ ] [Documention](insert_your_link_here) for enabling and using the feature.
+- [ ] [Documentation](insert_your_link_here) for enabling and using the feature.
 
 [//]: # (The documentation instructions may exist on the developer wiki or the team drive. They may include instructions)
 [//]: # (for building running a `istioctl experimental command`, or using the preview profile,)

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -3,31 +3,66 @@ name: Experimental Feature Requirements
 about: Requirements for an experimental feature
 ---
 
-# Experimental feature requirements
+[//]: # (The syntax preceeding this line is a comment marker used to help guide the issue author with submission of an issue)
+[//]: # (to github. Unlike HTML comments commonly used throughout istio.io documentation, this comment will not be rendered)
+[//]: # (by github. Comments must be separated by carriage return preceding and concluding the text and be a single line.)
 
-This page lists the requirements for an experimental feature. Completion of this template enables Istio work groups to collect
-information on potential new functionality. This template should be completed before users are exposed to any new
-experimental feature. Please complete this template during development.
+[//]: # (This page lists the requirements for an experimental feature. Completion of this template enables Istio work groups)
+[//]: # (to collect information on potential new functionality. This template should be completed before users are exposed to)
+[//]: # (any new experimental feature. Please complete this template during development.)
 
-This template shall be completed before users are exposed to any new experimental feature.
+[//]: # (The feature implementation section must be completed before submission of the issue.)
 
-# Mandatory fields for submission
+
+
+# Feature Information
+
+[//]: # (All information in this section is mandatory for new issue submission.)
 
 **Feature name:**
 
+[//]: # (The name of the feature, e.g. Multiple control planes)
+
 **Primary lead(s):**
 
+[//]: # (The primary lead or leads responsible for the feature. These individuals serve as a point of contact for the feature.)
+
+
 **Short description:**
+
+[//]: # (A short description of the feature. One or two sentences maximum.)
 
 --- 
 
 # Requirements:
 
+[//]: # (All information in this section is mandatory for promotion. Please edit the issue to modify the links in this)
+[//]: # (section.)
+
 - [ ] [User stories](insert_your_link_here) reviewed in a work group meeting.
-- [ ] [RFC Authored] - [create an RFC using template](https://docs.google.com/document/d/1ewJoCcw5-04crH-M0xw4zFxz1cfwVCPnNyW4K3m4Yyc/template/preview)
-- [ ] [Documented instructions](insert_your_link_here) for enabling and using the feature. This may include instructions for
-        building, running an `istioctl experimental command`, or using the preview profile.
-- [ ] [Feedback plan](insert_your_link_here). This may include user feedback meetings,
-	discuss.istio.io conversations, GitHub issues, or mailing lists.
+
+[//]: # (User stories are a way to communicate user value. User stories follow the style)
+[//]: # (as a [type of user], I want [an action] so that [a benefit/a value]. Istio currently has no user)
+[//]: # (story template. Maybe you can make one?)
+
+[//]: # (User stories must be presented in a work group meeting. They need no approval and are later integrated)
+[//]: # (into the RFCs, which do need approval for alpha. You may find value to negotiate within the work group where the)
+[//]: # (user stories are presented to help clarify the user stories.)
+
+- [ ] [RFC Authored] - [create an RFC using template](https://docs.google.com/document/d/1ewJoCcw5-04crH-M0xw4zFxz1cfwVCPnNyW4K3m4Yyc/template/preview).
+
+[//]: # (An RFC is mandatory to graduate to experimental. The RFC does not have to be reviewed in a work group)
+[//]: # (meeting to graduate to experimental.)
+
+- [ ] [Documention](insert_your_link_here) for enabling and using the feature.
+
+[//]: # (The documentation instructions may exist on the developer wiki or the team drive. They may include instructions)
+[//]: # (for building running a `istioctl experimental command`, or using the preview profile,)
+[//]: # (or any other relevant information.)
+
+- [ ] [Feedback plan](insert_your_link_here).
+
+[//]: # (This may include user feedback meetings, discuss.istio.io conversations, GitHub issues, or mailing lists.a)
+
 - [ ] Disabled by default.
 - [ ] No impact on performance when the feature is disabled.

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -1,31 +1,47 @@
 ---
 name: Experimental Feature Requirements
-about: Requirements for experimental features
+about: Requirements for an experimental feature
 ---
 
-# Experimental Feature Requirements
+# Experimental feature requirements
 
-This page lists the requirements for experimental features. Experimental features allow Istio work groups to collect more information
-on potential new functionality. This template should be completed before users try out any new experimental features. Please check off and 
-document the steps as they are completed.
+This page lists the requirements for an experimental feature. Completion of this template enables Istio work groups to collect
+information on potential new functionality. This template should be completed before users are exposed to any new
+experimental feature. Please complete this template during development.
 
-**Feature Name:** 
+This template shall be completed before users are exposed to any new experimetnal feature.
+
+# Mandatory fields for submission
+
+**Feature name:**
+
+**Primary lead:**
+
+**Short description:**
 
 --- 
 
-### Requirements: 
+# Requirements:
 
-- [ ] Feature is reviewed in a work group meeting
-- [ ] RFC has been written
+- [ ] Review of user stories in a work group meeting
+- [ ] RFC Authored
 - [ ] Feature is disabled by default
 - [ ] No impact on performance when the feature is disabled.
-- [ ] Steps for enabling the feature have been documented. This may include
-	instructions for building, running an `istioctl experimental command`, or
+- [ ] Instructions for enabling and using the feature have been documented. This may
+        include instructions for building, running an `istioctl experimental command`, or
 	using the preview profile. 
+- [ ] Feedback plan authoed. This may include user feedback meetings,
+	discuss.istio.io conversations, GitHub issues, or mailing lists.
+
+**User stories document:**
+
+**RFC document:**
+
+**Instructions document:**
+
+**Feedback plan:**
 
 > Link to instructions 
 
-- [ ] Plan exists for getting feedback. This may include user feedback meetings,
-	discuss.istio.io conversations, GitHub issues, or mailing lists. 
 
 > Plan for feedback

--- a/.github/ISSUE_TEMPLATE/experimental_feature.md
+++ b/.github/ISSUE_TEMPLATE/experimental_feature.md
@@ -9,13 +9,13 @@ This page lists the requirements for an experimental feature. Completion of this
 information on potential new functionality. This template should be completed before users are exposed to any new
 experimental feature. Please complete this template during development.
 
-This template shall be completed before users are exposed to any new experimetnal feature.
+This template shall be completed before users are exposed to any new experimental feature.
 
 # Mandatory fields for submission
 
 **Feature name:**
 
-**Primary lead:**
+**Primary lead(s):**
 
 **Short description:**
 
@@ -23,25 +23,11 @@ This template shall be completed before users are exposed to any new experimetna
 
 # Requirements:
 
-- [ ] Review of user stories in a work group meeting
-- [ ] RFC Authored
-- [ ] Feature is disabled by default
-- [ ] No impact on performance when the feature is disabled.
-- [ ] Instructions for enabling and using the feature have been documented. This may
-        include instructions for building, running an `istioctl experimental command`, or
-	using the preview profile. 
-- [ ] Feedback plan authoed. This may include user feedback meetings,
+- [ ] [User stories](insert_your_link_here) reviewed in a work group meeting.
+- [ ] [RFC Authored] - [create an RFC using template](https://docs.google.com/document/d/1ewJoCcw5-04crH-M0xw4zFxz1cfwVCPnNyW4K3m4Yyc/template/preview)
+- [ ] [Documented instructions](insert_your_link_here) for enabling and using the feature. This may include instructions for
+        building, running an `istioctl experimental command`, or using the preview profile.
+- [ ] [Feedback plan](insert_your_link_here). This may include user feedback meetings,
 	discuss.istio.io conversations, GitHub issues, or mailing lists.
-
-**User stories document:**
-
-**RFC document:** [create an RFC using template](https://docs.google.com/document/d/1ewJoCcw5-04crH-M0xw4zFxz1cfwVCPnNyW4K3m4Yyc/template/preview)
-
-**Instructions document:**
-
-**Feedback plan:**
-
-> Link to instructions 
-
-
-> Plan for feedback
+- [ ] Disabled by default.
+- [ ] No impact on performance when the feature is disabled.


### PR DESCRIPTION
Reduce initial work for submission of an experimental feature
- Require an identified lead
- Require a short description of the feature

As RFC/design/documentation work is completed, check off and link each work product.