### PR TITLE
Fix YAML formatting and add link

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2,8 +2,7 @@
 
 Maturity of features in Istio indicate to users what they can [expect](https://istio.io/latest/about/feature-stages/) by using these
 features. In Istio, we track these requirements using a [template](features/feature_template.md). Once all
-requirements for promoting a feature to the next level are met, the [features](features.yaml)
-file may be updated to indicate this maturity level.
+requirements for the next level are met, [features.yaml](features.yaml) can be updated in order to promote the feature.
 
 ## Features.yaml
 
@@ -14,21 +13,23 @@ entry as described below.
 
 ```
 features:
-  - name: "Protocols:HTTP1.1/HTTP2/gRPC/TCP"
+- name: "Stackdriver Integration"
+    link: "/docs/reference/config/proxy_extensions/stackdriver/"
     level:
-      - checkList: 
-        maturity:
-        nextExpectedPromotion:
-        area: Core 
-	deprecation:
-      - state:
-        begin:
-        details:
-		- replacement: 
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    deprecation:
+      state: "deprecated"
+      details:
+        replacement: "SelfDrivingStack integration"
+        next: "1.10"
+    area:  Observability
 ```
 
-* **Name** indicates the name of the feature.
-* **Area** indicates the area of the feature.
+* **name** indicates the name of the feature.
+* **area** indicates the area of the feature.
+* **link** indicates a primary link that users can navigate to in order to find out more about a feature. This link may be provided to users by tooling consuming features.yaml.
 * **level** indicates the maturity level of a feature.
 * **level.checklist** is the path to the checklist to track a feature's maturity.
 * **level.maturity** is the current maturity level of the feature. This can be `experimental`, `alpha`, `beta`, or `stable`. Experimental is an optional maturity level that can be skipped. For alpha, beta, and stable, all requirements for the previous levels must be met before a feature can meet the next level (i.e. a stable feature has met the requirements of both alpha and beta). There may be features for which a requirement is not applicable.

--- a/features.yaml
+++ b/features.yaml
@@ -1,258 +1,283 @@
 features:
   - name: "Protocols:HTTP1.1/HTTP2/gRPC/TCP"
     level:
-      - checklist:
-        maturity: Stable
-        nextExpectedPromotion:
-        area: Traffic Management
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Protocols:Websockets/MongoDB"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Traffic Control: label/content based routing, traffic shifting"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
+  - name: "Resilience features: timeouts, retries, connection pools, outlier detection"
+    level:
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Gateway: Ingress, Egress for all protocols"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "TLS termination and SNI Support in Gateways"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "SNI (multiple certs) at ingress"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Locality load balancing"
+    link: "/docs/tasks/traffic-management/locality-load-balancing/"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Enabling custom filters in Envoy"
     level:
-     - checklist:
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "CNI container interface"
     level:
-     - checklist: features/cni.md
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: features/cni.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Sidecar API"
+    link: "/docs/reference/config/networking/sidecar/"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "DNS Proxying"
+    link: "/docs/ops/configuration/traffic-management/dns-proxy/"
     level:
-     - checklist:
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Traffic Management
-  - name: "Service APIs"
-    level:
-     - checklist: features/service_apis.md
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Kubernetes Service APIs"
+    link: "/docs/tasks/traffic-management/ingress/gateway-api/"
     level:
-     - checklist:
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Traffic Management
+      checklist: features/service_apis.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Traffic Management
   - name: "Prometheus Integration"
+    link: "/docs/tasks/observability/metrics/querying-metrics/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Observability
-  - name: "Client and Server Telemetry Reporting"
-    level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "Service Dashboard in Grafana"
+    link: "/docs/tasks/observability/metrics/using-istio-dashboard/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "Distributed Tracing"
+    link: "/docs/tasks/observability/distributed-tracing/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "Stackdriver Integration"
+    link: "/docs/reference/config/proxy_extensions/stackdriver/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "Distributed Tracing to Zipkin/Jaeger"
+    link: "/docs/tasks/observability/distributed-tracing/"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "Trace Sampling"
+    link: "/docs/tasks/observability/distributed-tracing/configurability/#trace-sampling"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "Request Classification"
+    link: "/docs/tasks/observability/metrics/classify-metrics/"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Observability
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Observability
   - name: "WebAssembly Extension"
     level:
-     - checklist:
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Extensibility
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Extensibility
   - name: "Service-to-service Mutual TLS"
+    link: "/docs/concepts/security/#mutual-tls-authentication"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "Kubernetes: Service Credential Distribution"
+    link: "/docs/concepts/security/#pki"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "Certificate management on Ingress Gateway"
+    link: "/docs/tasks/traffic-management/ingress/secure-ingress"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "Pluggable Key/Cert Support for istio CA"
+    link: "/docs/tasks/security/cert-management/plugin-ca-cert/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "Authorization"
+    link: "/docs/concepts/security/#authorization"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "End User (JWT) Authentication"
+    link: "/docs/concepts/security/#authentication"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "Automatic mutual TLS"
+    link: "/docs/tasks/security/authentication/authn-policy/#auto-mutual-tls"
     level:
-     - checklist: features/auto_mtls.md
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: features/auto_mtls.md
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "VM: Service Credential Distribution"
+    link: "/docs/concepts/security/#pki"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "Mutual TLS Migration"
+    link: "/docs/tasks/security/authentication/mtls-migration"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Security and policy enforcement
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Security and policy enforcement
   - name: "In-Cluster Operator"
+    link: "/docs/setup/install/operator/"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Kubernetes: Envoy Installation and Traffic Interception"
+    link: "/docs/setup/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Kubernetes: Istio Control Plane Installation"
+    link: "/docs/setup/"
     level:
-     - checklist:
-       maturity: Stable
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Stable
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Multicluster Mesh"
+    link: "/docs/setup/install/multicluster/"
     level:
-     - checklist: features/Multi-cluster support.md
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Core
+      checklist: features/Multi-cluster support.md
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
   - name: "External Control Plane"
+    link: "/docs/setup/additional-setup/external-controlplane/"
     level:
-     - checklist: features/external_istiod.md
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Core
+      checklist: features/external_istiod.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Kubernetes: Istio In-Place Control Plane Upgrade"
+    link: "/docs/setup/upgrade/in-place"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Basic Configuration Resource Validation"
     level:
-     - checklist:
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Istio CNI Plugin"
+    link: "/docs/setup/additional-setup/cni/"
     level:
-     - checklist:
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core
   - name: "IPv6 Support for Kubernetes"
     level:
-     - checklist:
-       maturity: Alpha. Dual-stack IPv4 and IPv6 is not supported.
-       nextExpectedPromotion:
-       area: Core
+      checklist: ""
+      maturity: Alpha. Dual-stack IPv4 and IPv6 is not supported.
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Distroless Base Images for Istio"
+    link: "/docs/ops/configuration/security/harden-docker-images/"
     level:
-     - checklist: features/distroless_images.md
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Core
+      checklist: features/distroless_images.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Virtual Machine Integration"
+    link: "/docs/setup/install/virtual-machine/"
     level:
-     - checklist: features/virtual_machines.md
-       maturity: Beta
-       nextExpectedPromotion:
-       area: Core
+      checklist: features/virtual_machines.md
+      maturity: Beta
+      nextExpectedPromotion: ""
+    area: Core
   - name: "Helm Based Installation"
+    link: "/docs/setup/install/helm/"
     level:
-     - checklist: features/helm_v3_support.md
-       maturity: Alpha
-       nextExpectedPromotion:
-       area: Core
+      checklist: features/helm_v3_support.md
+      maturity: Alpha
+      nextExpectedPromotion: ""
+    area: Core

--- a/features/feature_template.md
+++ b/features/feature_template.md
@@ -77,6 +77,10 @@
 
 - [ ] No impact on performance when the feature is disabled.
 
+
+[//]: # (Once all other items are completed, features.yaml should be updated to promote the feature)
+
+- [ ] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature
 ---
 
 ## Alpha
@@ -114,6 +118,12 @@
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
 - [ ] The TOC has reviewed and approved promotion of the feature as part of the
 	roadmap for a release.
+
+**Promotion**
+
+[//]: # (Once all other items are completed, features.yaml should be updated to promote the feature)
+
+- [ ] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature
 
 ---
 
@@ -168,6 +178,12 @@
 - [ ] The TOC has reviewed and approved promotion of the feature as part of the
 	road map for a release.
 
+
+**Promotion**
+
+[//]: # (Once all other items are completed, features.yaml should be updated to promote the feature)
+
+- [ ] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature
 ---
 
 ## Stable
@@ -191,3 +207,8 @@
 	roadmap for a release.
 
 
+**Promotion**
+
+[//]: # (Once all other items are completed, features.yaml should be updated to promote the feature)
+
+- [ ] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature


### PR DESCRIPTION
This fixes the YAML formatting in features.yaml and cleans up the text in features.md a bit. It also updates features.yaml to include an optional link field for a specific link to the feature. 

The list of links in the markdown for a feature provide a list of related links to help developers evaluate and understand a feature and it's maturity. In contrast, the link in features.yaml is designed to be consumed by other tooling and rendered as appropriate to point users at information concerning that feature.

See also https://github.com/istio/istio.io/pull/9533/files