### PR TITLE
Add features schema

### DIFF
--- a/FEATURES.md
+++ b/FEATURES.md
@@ -2,7 +2,7 @@
 
 Maturity of features in Istio indicate to users what they can [expect](https://istio.io/latest/about/feature-stages/) by using these
 features. In Istio, we track these requirements using a [template](features/feature_template.md). Once all
-requirements for the next level are met, [features.yaml](features.yaml) can be updated in order to promote the feature.
+requirements for the next level are met, [features.yaml](features.yaml) can be updated in order to promote the feature. The schema can be found in [features_schema.json](features_schema.json)
 
 ## Features.yaml
 
@@ -18,6 +18,7 @@ features:
     level:
       checklist: ""
       maturity: Stable
+      maturityNotes: "This is a test"
       nextExpectedPromotion: ""
     deprecation:
       state: "deprecated"
@@ -33,6 +34,7 @@ features:
 * **level** indicates the maturity level of a feature.
 * **level.checklist** is the path to the checklist to track a feature's maturity.
 * **level.maturity** is the current maturity level of the feature. This can be `experimental`, `alpha`, `beta`, or `stable`. Experimental is an optional maturity level that can be skipped. For alpha, beta, and stable, all requirements for the previous levels must be met before a feature can meet the next level (i.e. a stable feature has met the requirements of both alpha and beta). There may be features for which a requirement is not applicable.
+* **level.maturityNotes** Specific notes that may be needed alongside a maturity level.
 * **level.nextExpectedPromotion** indicates the Istio release by which the next promotion of a feature is expected. Up until a feature is stable, a feature is expected to continuously mature. If a feature doesn't get promoted, this should be extended or the feature should be deprecated.  In some rare circumstances, features will be permanently in a state below stable and never expected to be promoted. For those circumstances, this field can be marked `never`.
 * **deprecation** describes details of deprecated features. 
 * **deprecation.state** This can be `deprecated` or `retired`. When a feature is deprecated, users should consider migrating to a replacement as retired features may be removed. Deprecation time varies depending on the [current maturity level](https://istio.io/latest/about/feature-stages/).

--- a/features.yaml
+++ b/features.yaml
@@ -263,7 +263,8 @@ features:
   - name: "IPv6 Support for Kubernetes"
     level:
       checklist: ""
-      maturity: Alpha. Dual-stack IPv4 and IPv6 is not supported.
+      maturity: Alpha
+      maturityNotes: Dual-stack IPv4 and IPv6 is not supported.
       nextExpectedPromotion: ""
     area: Core
   - name: "Distroless Base Images for Istio"

--- a/features_schema.json
+++ b/features_schema.json
@@ -1,0 +1,81 @@
+{
+    "$id": "istio.io/features",
+    "$schema": "https://json-schema.org/draft/2020-12/schema",
+    "description": "Defines the maturity of features in Istio",
+    "type": "object",
+    "properties": {
+      "features": {
+        "type": "array",
+        "items": {
+            "type": "object",
+            "properties": {
+                "name": {
+                    "type": "string",
+                    "description": "The name of the feature."
+                },
+                "link": {
+                    "type": "string",
+                    "description":"A primary link that users can navigate to in order to find out more about a feature. This link may be provided to users by tooling consuming features.yaml."
+                },
+                "area": {
+                    "type": "string",
+                    "description":"The area of the feature.",
+                    "enum": ["Traffic Management", "Observability", "Extensibility", "Security and policy enforcement", "Core"]
+                },
+                "level": {
+                    "type":"object",
+                    "properties": {
+                        "checklist": {
+                            "type": "string",
+                            "description":"The path to the checklist to track a feature's maturity."
+                        },
+                        "maturity": {
+                            "type": "string",
+                            "description":"The current maturity level of the feature. This can be experimental, alpha, beta, or stable. Experimental is an optional maturity level that can be skipped. For alpha, beta, and stable, all requirements for the previous levels must be met before a feature can meet the next level (i.e. a stable feature has met the requirements of both alpha and beta). There may be features for which a requirement is not applicable.",
+                            "enum": ["Experimental","Alpha","Beta","Stable"]
+                        },
+                        "maturity_notes": {
+                            "type": "string",
+                            "description":"Specific notes that may be needed alongside a maturity level."
+                        },
+                        "nextExpectedPromotion": {
+                            "type": "string",
+                            "description":"The Istio release by which the next promotion of a feature is expected. Up until a feature is stable, a feature is expected to continuously mature. If a feature doesn't get promoted, this should be extended or the feature should be deprecated. In some rare circumstances, features will be permanently in a state below stable and never expected to be promoted. For those circumstances, this field can be marked never."
+                        }
+                    },
+                    "required": ["checklist", "maturity"]
+                },
+                "deprecation": {
+                    "type": "object",
+                    "properties": {
+                        "state": {
+                            "type": "string",
+                            "description":"This can be deprecated or retired. When a feature is deprecated, users should consider migrating to a replacement as retired features may be removed. Deprecation time varies depending on the current maturity level.",
+                            "enum": ["deprecated", "retired"]
+                        },
+                        "details": {
+                            "type": "object",
+                            "description":"Should be set when a feature moves out of the active state.",
+                            "properties": {
+                                "replacement": {
+                                    "type": "string",
+                                    "description":"Should specify the checklist(s) for any feature replacing this deprecated feature."
+                                },
+                                "next": {
+                                    "type": "string",
+                                    "description":"Indicates the release in which the feature will be retired."
+                                }
+                            },
+                            "required": ["next"]
+                        }
+                    },
+                    "required": ["state", "details"]
+                }
+            }
+        },
+        "required": ["name", "level"]
+      }
+    },
+    "required": [ "features" ]
+  }
+  

--- a/features_schema.json
+++ b/features_schema.json
@@ -4,78 +4,105 @@
     "description": "Defines the maturity of features in Istio",
     "type": "object",
     "properties": {
-      "features": {
-        "type": "array",
-        "items": {
-            "type": "object",
-            "properties": {
-                "name": {
-                    "type": "string",
-                    "description": "The name of the feature."
-                },
-                "link": {
-                    "type": "string",
-                    "description":"A primary link that users can navigate to in order to find out more about a feature. This link may be provided to users by tooling consuming features.yaml."
-                },
-                "area": {
-                    "type": "string",
-                    "description":"The area of the feature.",
-                    "enum": ["Traffic Management", "Observability", "Extensibility", "Security and policy enforcement", "Core"]
-                },
-                "level": {
-                    "type":"object",
-                    "properties": {
-                        "checklist": {
-                            "type": "string",
-                            "description":"The path to the checklist to track a feature's maturity."
-                        },
-                        "maturity": {
-                            "type": "string",
-                            "description":"The current maturity level of the feature. This can be experimental, alpha, beta, or stable. Experimental is an optional maturity level that can be skipped. For alpha, beta, and stable, all requirements for the previous levels must be met before a feature can meet the next level (i.e. a stable feature has met the requirements of both alpha and beta). There may be features for which a requirement is not applicable.",
-                            "enum": ["Experimental","Alpha","Beta","Stable"]
-                        },
-                        "maturity_notes": {
-                            "type": "string",
-                            "description":"Specific notes that may be needed alongside a maturity level."
-                        },
-                        "nextExpectedPromotion": {
-                            "type": "string",
-                            "description":"The Istio release by which the next promotion of a feature is expected. Up until a feature is stable, a feature is expected to continuously mature. If a feature doesn't get promoted, this should be extended or the feature should be deprecated. In some rare circumstances, features will be permanently in a state below stable and never expected to be promoted. For those circumstances, this field can be marked never."
-                        }
+        "features": {
+            "type": "array",
+            "items": {
+                "type": "object",
+                "properties": {
+                    "name": {
+                        "type": "string",
+                        "description": "The name of the feature."
                     },
-                    "required": ["checklist", "maturity"]
-                },
-                "deprecation": {
-                    "type": "object",
-                    "properties": {
-                        "state": {
-                            "type": "string",
-                            "description":"This can be deprecated or retired. When a feature is deprecated, users should consider migrating to a replacement as retired features may be removed. Deprecation time varies depending on the current maturity level.",
-                            "enum": ["deprecated", "retired"]
-                        },
-                        "details": {
-                            "type": "object",
-                            "description":"Should be set when a feature moves out of the active state.",
-                            "properties": {
-                                "replacement": {
-                                    "type": "string",
-                                    "description":"Should specify the checklist(s) for any feature replacing this deprecated feature."
-                                },
-                                "next": {
-                                    "type": "string",
-                                    "description":"Indicates the release in which the feature will be retired."
-                                }
+                    "link": {
+                        "type": "string",
+                        "description": "A primary link that users can navigate to in order to find out more about a feature. This link may be provided to users by tooling consuming features.yaml."
+                    },
+                    "area": {
+                        "type": "string",
+                        "description": "The area of the feature.",
+                        "enum": [
+                            "Traffic Management",
+                            "Observability",
+                            "Extensibility",
+                            "Security and policy enforcement",
+                            "Core"
+                        ]
+                    },
+                    "level": {
+                        "type": "object",
+                        "properties": {
+                            "checklist": {
+                                "type": "string",
+                                "description": "The path to the checklist to track a feature's maturity."
                             },
-                            "required": ["next"]
-                        }
+                            "maturity": {
+                                "type": "string",
+                                "description": "The current maturity level of the feature. This can be experimental, alpha, beta, or stable. Experimental is an optional maturity level that can be skipped. For alpha, beta, and stable, all requirements for the previous levels must be met before a feature can meet the next level (i.e. a stable feature has met the requirements of both alpha and beta). There may be features for which a requirement is not applicable.",
+                                "enum": [
+                                    "Experimental",
+                                    "Alpha",
+                                    "Beta",
+                                    "Stable"
+                                ]
+                            },
+                            "maturity_notes": {
+                                "type": "string",
+                                "description": "Specific notes that may be needed alongside a maturity level."
+                            },
+                            "nextExpectedPromotion": {
+                                "type": "string",
+                                "description": "The Istio release by which the next promotion of a feature is expected. Up until a feature is stable, a feature is expected to continuously mature. If a feature doesn't get promoted, this should be extended or the feature should be deprecated. In some rare circumstances, features will be permanently in a state below stable and never expected to be promoted. For those circumstances, this field can be marked never."
+                            }
+                        },
+                        "required": [
+                            "checklist",
+                            "maturity"
+                        ]
                     },
-                    "required": ["state", "details"]
-                }
+                    "deprecation": {
+                        "type": "object",
+                        "properties": {
+                            "state": {
+                                "type": "string",
+                                "description": "This can be deprecated or retired. When a feature is deprecated, users should consider migrating to a replacement as retired features may be removed. Deprecation time varies depending on the current maturity level.",
+                                "enum": [
+                                    "deprecated",
+                                    "retired"
+                                ]
+                            },
+                            "details": {
+                                "type": "object",
+                                "description": "Should be set when a feature moves out of the active state.",
+                                "properties": {
+                                    "replacement": {
+                                        "type": "string",
+                                        "description": "Should specify the checklist(s) for any feature replacing this deprecated feature."
+                                    },
+                                    "next": {
+                                        "type": "string",
+                                        "description": "Indicates the release in which the feature will be retired."
+                                    }
+                                },
+                                "required": [
+                                    "next"
+                                ]
+                            }
+                        },
+                        "required": [
+                            "state",
+                            "details"
+                        ]
+                    }
+                },
+                "required": [
+                    "name",
+                    "level",
+                    "area"
+                ]
             }
-        },
-        "required": ["name", "level"]
-      }
+        }
     },
-    "required": [ "features" ]
-  }
-  
+    "required": [
+        "features"
+    ]
+}


### PR DESCRIPTION
This adds a schema for validating `features.yaml`. It also separates maturity and maturityNotes such that maturity can be an enum and additional notes can be added if needed. 