### PR TITLE
features_schema.json: Fix missing camelCase in "maturityNotes".

### DIFF
--- a/features_schema.json
+++ b/features_schema.json
@@ -45,7 +45,7 @@
                                     "Stable"
                                 ]
                             },
-                            "maturity_notes": {
+                            "maturityNotes": {
                                 "type": "string",
                                 "description": "Specific notes that may be needed alongside a maturity level."
                             },


### PR DESCRIPTION
All fields in this file use camelCase except "maturity_notes".  The existing "features.yaml" file and example that reference this schema already used the camelCase "maturityNotes".