### PR TITLE
Promote external control plane feature to beta

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -249,7 +249,7 @@ features:
     link: "/docs/setup/install/external-controlplane/"
     level:
       checklist: features/external_istiod.md
-      maturity: Alpha
+      maturity: Beta
       nextExpectedPromotion: ""
     area: Core
   - name: "Kubernetes: Istio In-Place Control Plane Upgrade"

--- a/features/external_istiod.md
+++ b/features/external_istiod.md
@@ -141,7 +141,7 @@ No API added in 1.8
 
 **Tests**
 
-- [ ] Integration tests cover feature edge cases (Note: The integration test framework has been updated to fully support the external control plane topology, and basic testing is in place. The remaining tests needed for full coverage already exist (MC test suite) and will be added to the external control plane suite in the comming weeks).
+- [ ] Integration tests cover feature edge cases (Note: The integration test framework has been updated to fully support the external control plane topology, and basic testing is in place. The remaining tests needed for full coverage already exist (MC test suite) and will be added to the external control plane suite in the coming weeks).
 - [x] End-to-end tests cover samples/tutorials
 - [x] Fixed issues have tests to prevent regressions
 - [x] Stability/stress test suite includes coverage for the feature.

--- a/features/external_istiod.md
+++ b/features/external_istiod.md
@@ -141,7 +141,7 @@ No API added in 1.8
 
 **Tests**
 
-- [ ] Integration tests cover feature edge cases
+- [ ] Integration tests cover feature edge cases (Note: The integration test framework has been updated to fully support the external control plane topology, and basic testing is in place. The remaining tests needed for full coverage already exist (MC test suite) and will be added to the external control plane suite in the comming weeks).
 - [x] End-to-end tests cover samples/tutorials
 - [x] Fixed issues have tests to prevent regressions
 - [x] Stability/stress test suite includes coverage for the feature.

--- a/features/external_istiod.md
+++ b/features/external_istiod.md
@@ -141,7 +141,7 @@ No API added in 1.8
 
 **Tests**
 
-- [ ] Integration tests cover feature edge cases (Note: The integration test framework has been updated to fully support the external control plane topology, and basic testing is in place. The remaining tests needed for full coverage already exist (MC test suite) and will be added to the external control plane suite in the coming weeks).
+- [x] Integration tests cover feature edge cases (Note: The integration test framework has been updated to fully support the external control plane topology, and basic testing is in place. The remaining tests needed for full coverage already exist (MC test suite) and will be added to the external control plane suite in the coming weeks).
 - [x] End-to-end tests cover samples/tutorials
 - [x] Fixed issues have tests to prevent regressions
 - [x] Stability/stress test suite includes coverage for the feature.

--- a/features/external_istiod.md
+++ b/features/external_istiod.md
@@ -16,7 +16,7 @@
 
 [//]: # (The name of the feature, e.g. Multiple control planes)
 
-**Primary lead(s):** Lin Sun
+**Primary lead(s):** Frank Budinsky, Eric Van Norman
 
 [//]: # (The primary lead or leads responsible for the feature. These individuals serve as a point of contact for the feature.)
 
@@ -135,7 +135,7 @@ No API added in 1.8
 - [x] Documentation on istio.io includes performance expectations; may have caveats. 
 - [x] Documentation on istio.io includes samples/tutorials. 
 - [x] Documentation on istio.io includes appropriate glossary entries. 
-- [ ] All new documentation containing user actions includes istio.io tests.
+- [x] All new documentation containing user actions includes istio.io tests.
 - [x] Release notes have been added. 
 - [x] Upgrade notes have been added. 
 
@@ -161,12 +161,12 @@ No API added in 1.8
 
 **Bugs**
 
-- [ ] Feature has no known major issues.
+- [x] Feature has no known major issues.
 
 **Approvals**
 
 - [x] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The supportability review panel has reviewed promotion of the feature.  
+- [x] The supportability review panel has reviewed promotion of the feature.
 - [x] The TOC has reviewed and approved promotion of the feature as part of the
 	road map for a release.
 

--- a/features/external_istiod.md
+++ b/features/external_istiod.md
@@ -128,7 +128,7 @@ No API added in 1.8
 - [x] Design doc describing the intention of the feature, how it will be
 	implemented, and any thoughts on how to test the feature has been approved by
 	relevant work group leads
-- [ ] Feature coverage and test plans written and approved.
+- [x] Feature coverage and test plans written and approved.
 
 **Docs** 
 
@@ -143,13 +143,13 @@ No API added in 1.8
 
 - [ ] Integration tests cover feature edge cases
 - [x] End-to-end tests cover samples/tutorials
-- [ ] Fixed issues have tests to prevent regressions
-- [ ] Stability/stress test suite includes coverage for the feature.
+- [x] Fixed issues have tests to prevent regressions
+- [x] Stability/stress test suite includes coverage for the feature.
 
 **Performance**
 
-- [ ] Feature coverage and test plans written and approved 
-- [ ] Tests exist with the feature enabled that can be integrated with our automated performance testing.
+- [x] Feature coverage and test plans written and approved
+- [x] Tests exist with the feature enabled that can be integrated with our automated performance testing.
 
 **API**
 


### PR DESCRIPTION
The external control plane feature is functionally ready to be promoted to `Beta`.

The only possible issue is that it's somewhat light on testing, although it does have basic integration testing and doc testing which should be sufficient for `Beta` promotion in release 1.11. More robust and complete testing will be added in 1.12+ in preparation for later promotion to `Stable`.

**Current Test Summary**

1. Doc test for helloworld service and gateway deployment with [single cluster external control plane setup](https://preliminary.istio.io/latest/docs/setup/install/external-controlplane/).
2. Doc test for helloworld running on two clusters (config and remote), i.e., a [multicluster external control plane setup](https://preliminary.istio.io/latest/docs/setup/install/external-controlplane/#adding-clusters).
3. Integration test for single config cluster with external control plane - confirms istiod connectivity including injection webhook is functioning. 
4. Integration test for multicluster reachability using an external control plane (TBD: will be added before 1.11 release) 
