### PR TITLE
Update template to make supportability review optional

### DIFF
--- a/features/feature_template.md
+++ b/features/feature_template.md
@@ -174,7 +174,7 @@
 **Approvals**
 
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The supportability review panel has reviewed promotion of the feature.  
+- [ ] The supportability review panel has reviewed promotion of the feature OR a WG has decided one is not required.  
 - [ ] The TOC has reviewed and approved promotion of the feature as part of the
 	road map for a release.
 
@@ -202,7 +202,7 @@
 **Approvals**
 
 - [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The [supportability review panel](https://docs.google.com/document/d/1w0epyFhhDSf_TwFEfa_lrn1v61mXNJKpEp_kUgp4sSc/edit#) has reviewed the feature in order to find any supportability concerns.  
+- [ ] The [supportability review panel](https://docs.google.com/document/d/1w0epyFhhDSf_TwFEfa_lrn1v61mXNJKpEp_kUgp4sSc/edit#) has reviewed the feature in order to find any supportability concerns OR a WG has decided one is not required.  
 - [ ] The TOC has reviewed and approved promotion of the feature as part of the
 	roadmap for a release.
 


### PR DESCRIPTION
Not all features require supportability reviews, WGs should decide if in doubt.