### PR TITLE
promote multicluster to stable in 1.13

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -280,7 +280,7 @@ features:
     link: "/docs/setup/install/multicluster/"
     level:
       checklist: features/Multi-cluster support.md
-      maturity: Beta
+      maturity: Stable
       nextExpectedPromotion: ""
     area: Core
   - name: "External Control Plane"

--- a/features/Multi-cluster support.md
+++ b/features/Multi-cluster support.md
@@ -90,34 +90,34 @@
 
 **Design**
 
-- [ ] RFC has been approved describing the intention of the feature as well as the user stories behind the feature. 
+- [x] RFC has been approved describing the intention of the feature as well as the user stories behind the feature. 
 
 **Config**
 
-- [ ] Explicit user action is required to enable this feature (e.g. a config field, config resource, or installation action). 
+- [x] Explicit user action is required to enable this feature (e.g. a config field, config resource, or installation action). 
 
 > Link to instructions for enabling
 
 **Docs**
 
-- [ ] Reference docs are published to preliminary.istio.io or the Istio wiki.
-- [ ] Basic feature docs are published on preliminary.istio.io describing what the feature does, how to use it, and any caveats. 
-- [ ] Release notes entries added as appropriate
-- [ ] Upgrade notes entries added as appropriate
+- [x] Reference docs are published to preliminary.istio.io or the Istio wiki.
+- [x] Basic feature docs are published on preliminary.istio.io describing what the feature does, how to use it, and any caveats. 
+- [x] Release notes entries added as appropriate
+- [x] Upgrade notes entries added as appropriate
 
 **Tests**
 
-- [ ] Automated integration tests cover core use cases with the feature enabled. 
-- [ ] When disabled, the feature does not affect system stability or performance. 
+- [x] Automated integration tests cover core use cases with the feature enabled. 
+- [x] When disabled, the feature does not affect system stability or performance. 
 
 **API**
 
-- [ ] Initial API review.
+- [x] Initial API review.
 
 **Approvals**
 
-- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+- [x] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [x] The TOC has reviewed and approved promotion of the feature as part of the
 	roadmap for a release.
 
 ---
@@ -128,49 +128,49 @@
 
 **Design**
 
-- [ ] Design doc describing the intention of the feature, how it will be
+- [x] Design doc describing the intention of the feature, how it will be
 	implemented, and any thoughts on how to test the feature has been approved by
 	relevant work group leads
-- [ ] Feature coverage and test plans written and approved.
+- [x] Feature coverage and test plans written and approved.
 
 **Docs** 
 
-- [ ] Documentation on istio.io includes performance expectations; may have caveats. 
-- [ ] Documentation on istio.io includes samples/tutorials. 
-- [ ] Documentation on istio.io includes appropriate glossary entries. 
-- [ ] All new documentation containing user actions includes istio.io tests.
-- [ ] Release notes have been added. 
-- [ ] Upgrade notes have been added. 
+- [x] Documentation on istio.io includes performance expectations; may have caveats. 
+- [x] Documentation on istio.io includes samples/tutorials. 
+- [x] Documentation on istio.io includes appropriate glossary entries. 
+- [x] All new documentation containing user actions includes istio.io tests.
+- [x] Release notes have been added. 
+- [x] Upgrade notes have been added. 
 
 **Tests**
 
-- [ ] Integration tests cover feature edge cases
-- [ ] End-to-end tests cover samples/tutorials
-- [ ] Fixed issues have tests to prevent regressions
-- [ ] Stability/stress test suite includes coverage for the feature.
+- [x] Integration tests cover feature edge cases
+- [x] End-to-end tests cover samples/tutorials
+- [x] Fixed issues have tests to prevent regressions
+- [x] Stability/stress test suite includes coverage for the feature.
 
 **Performance**
 
-- [ ] Feature coverage and test plans written and approved 
-- [ ] Tests exist with the feature enabled that can be integrated with our automated performance testing.
+- [x] Feature coverage and test plans written and approved 
+- [x] Tests exist with the feature enabled that can be integrated with our automated performance testing.
 
 **API**
 
-- [ ] TOC has reviewed the API and determined it to be complete. 
+- [x] TOC has reviewed the API and determined it to be complete. 
 
 **Tooling**
 
-- [ ] Any necessary tooling to use/debug the feature has been implemented and is complete. 
+- [x] Any necessary tooling to use/debug the feature has been implemented and is complete. 
 
 **Bugs**
 
-- [ ] Feature has no known major issues.
+- [x] Feature has no known major issues.
 
 **Approvals**
 
-- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The supportability review panel has reviewed promotion of the feature.  
-- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+- [x] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [x] The supportability review panel has reviewed promotion of the feature.  
+- [x] The TOC has reviewed and approved promotion of the feature as part of the
 	road map for a release.
 
 ---
@@ -181,18 +181,18 @@
 
 **Performance**
 
-- [ ] Latency, throughput, and scalability are quantified and documented on
+- [X] Latency, throughput, and scalability are quantified and documented on
 	istio.io. 
 
 **Bugs**
 
-- [ ] Feature has no known major issues. 
+- [X] Feature has no known major issues. 
 
 **Approvals**
 
-- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
-- [ ] The supportability review panel has reviewed promotion of the feature.  
-- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+- [X] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [X] The supportability review panel has reviewed promotion of the feature.  
+- [X] The TOC has reviewed and approved promotion of the feature as part of the
 	roadmap for a release.
 
 


### PR DESCRIPTION
Testing:

- [x] Multi-cluster has strong coverage across all features. New tests are generally written to be multi-cluster by default.
- [x] added Multi-Revision testing: https://github.com/istio/istio/pull/35331
- [ ] Improve support for removing a cluster, or replacing it's remote secret

Features/improvements (some of these were added prior to 1.12, but after the beta promotion):
- [x] Cross-cluster headless services: https://github.com/istio/istio/pull/35883
- [x] Move tooling out of `x/experimental`: https://github.com/istio/istio/pull/35509 
- [x] Allow selecting on cluster id in destination rule: https://github.com/istio/istio/pull/27971
- [x] Remove the 2x watches on multi-cluster secrets: https://github.com/istio/istio/pull/35674
Documentation:
- [x] Cover the options for making a service "cluster-local" without relying  on `meshConfig.servicesettings` 
- [x] Better explain the concept of "namespace sameness" ([SIG Multicluster statement](https://github.com/kubernetes/community/blob/master/sig-multicluster/namespace-sameness-position-statement.md)) 
- [x] Add instructions to run bug-report per-cluster on https://istio.io/latest/docs/ops/diagnostic-tools/multicluster/
- [ ] Highlight in feature status that "remote clusters" and "multi network" have separate statuses. 
