### PR TITLE
Add the link for Gateway Network Topology

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -95,6 +95,7 @@ features:
     area: Traffic Management
     id: "traffic.k8s_gateway_apis"
   - name: "Gateway Network Topology Configuration"
+    link: "/docs/ops/configuration/traffic-management/network-topologies/"
     id: "traffic.gateway_topology"
     level:
        checklist: features/configuring_gateway_network_topology.md


### PR DESCRIPTION
This PR adds the link for Gateway Network Topology under the [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml)

Fixes #151