### PR TITLE
Promote Telemetry API to v1

### DIFF
--- a/features.yaml
+++ b/features.yaml
@@ -395,7 +395,7 @@ features:
     link: "https://istio.io/latest/docs/tasks/observability/telemetry/"
     level:
       checklist: features/telemetry_api.md
-      maturity: Alpha
+      maturity: Stable
       nextExpectedPromotion: ""
   - name: "Dual Stack Support in Istio"
     id: "core.dual_stack"

--- a/features/telemetry_api.md
+++ b/features/telemetry_api.md
@@ -52,6 +52,7 @@ The Telemetry API enables control of the telemetry production within a mesh.
 
 - [RFC: Telemetry API](https://docs.google.com/document/d/1Tv-A2eftrNQrouMsdBLiHdILIwVN3n2c7RJYNVuv7GY/edit#)
 - [RFC: Telemetry API Scope](https://docs.google.com/document/d/1PfmqSpO5c3jCdQ__DppPYlW9IzupSkA5WhuOTGGwlK8/edit#)
+- [Telemetry v1 API](https://docs.google.com/document/d/16A-E-30txN5Y2V_9qrDNpVC3lT7P6aa_3Qdg6_4t5Sg/edit)
 
 ---
 
@@ -175,7 +176,7 @@ The Telemetry API enables control of the telemetry production within a mesh.
 
 **API**
 
-- [ ] TOC has reviewed the API and determined it to be complete.
+- [x] TOC has reviewed the API and determined it to be complete.
 
 **Tooling**
 
@@ -183,13 +184,13 @@ The Telemetry API enables control of the telemetry production within a mesh.
 
 **Bugs**
 
-- [ ] Feature has no known major issues.
+- [x] Feature has no known major issues.
 
 **Approvals**
 
-- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [x] The appropriate work group(s) have reviewed and approved promotion of the feature.
 - [ ] The supportability review panel has reviewed promotion of the feature OR a WG has decided one is not required.
-- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+- [x] The TOC has reviewed and approved promotion of the feature as part of the
 	road map for a release.
 
 
@@ -197,7 +198,7 @@ The Telemetry API enables control of the telemetry production within a mesh.
 
 [//]: # (Once all other items are completed, features.yaml should be updated to promote the feature)
 
-- [ ] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature
+- [x] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature
 ---
 
 ## Stable
@@ -215,9 +216,9 @@ The Telemetry API enables control of the telemetry production within a mesh.
 
 **Approvals**
 
-- [ ] The appropriate work group(s) have reviewed and approved promotion of the feature.
+- [x] The appropriate work group(s) have reviewed and approved promotion of the feature.
 - [ ] The [supportability review panel](https://docs.google.com/document/d/1w0epyFhhDSf_TwFEfa_lrn1v61mXNJKpEp_kUgp4sSc/edit#) has reviewed the feature in order to find any supportability concerns OR a WG has decided one is not required.
-- [ ] The TOC has reviewed and approved promotion of the feature as part of the
+- [x] The TOC has reviewed and approved promotion of the feature as part of the
 	roadmap for a release.
 
 
@@ -225,4 +226,4 @@ The Telemetry API enables control of the telemetry production within a mesh.
 
 [//]: # (Once all other items are completed, features.yaml should be updated to promote the feature)
 
-- [ ] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature
+- [x] [features.yaml](https://github.com/istio/enhancements/blob/master/features.yaml) updated for this feature


### PR DESCRIPTION
Part of #178 

Related to:
[api/3133](https://github.com/istio/api/pull/3133)
https://istio.io/latest/blog/2024/v1-apis/